### PR TITLE
Improve Windows 11 compatibility by using Shift instead of Ctrl key in hotkeys combinations

### DIFF
--- a/ChildLock.cpp
+++ b/ChildLock.cpp
@@ -30,7 +30,7 @@ BOOL CChildLock::Initialize(
     m_hInstance = hInstance;
     m_hwndMainWindow = hwndMainWindow;
 
-    m_bLockInputHotkeyID = fpnRegisterHotkey(bHandlerID, MOD_CONTROL | MOD_WIN, VkKeyScan(L'b'));
+    m_bLockInputHotkeyID = fpnRegisterHotkey(bHandlerID, MOD_SHIFT | MOD_WIN, VkKeyScan(L'b'));
 
     return TRUE;
 }


### PR DESCRIPTION
Update hotkey combination in `ChildLock.cpp` to use Shift instead of Ctrl.

* Replace `MOD_CONTROL` with `MOD_SHIFT` in the `Initialize` method when registering the hotkey.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sergey-rybalkin/LiveKeys/pull/1?shareId=8f51c450-cfb4-45e2-b89e-1d1ce53f283c).